### PR TITLE
Fixes to remove Rust alpha warnings

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -85,7 +85,7 @@ pub struct JackPositionT {
     pub bbt_offset: JackNframesT,
     pub audio_frames_per_video_frame: ::libc::c_float,
     pub video_offset: JackNframesT,
-    pub padding: [i32;7us],
+    pub padding: [i32;7usize],
     unique_2: JackUniqueT,
 }
 


### PR DESCRIPTION
- src/types.rs 'JackPostionT' changed padding to use 'usize' instead of
  depricated 'us'.
- src/lib.rs changed instances of 'std::ffi::c_str_to_bytes(ptr)' to
  'CStr::from_ptr(ptr).to_bytes()'
- src/lib.rs changes instances of 'CString::from_slice' to
  CString::new(slice).unwrap()'
- src/lib.rs removed 'hash' and 'std_misc' from #![feature()] -- not
  sure if the warnings that these didn't exist has anything to do with
  upgrade to rust alpha or not
